### PR TITLE
Do not generate code for default methods

### DIFF
--- a/auto-parallelizable/src/main/java/com/palantir/gradle/autoparallelizable/AutoParallelizableProcessor.java
+++ b/auto-parallelizable/src/main/java/com/palantir/gradle/autoparallelizable/AutoParallelizableProcessor.java
@@ -233,6 +233,10 @@ public final class AutoParallelizableProcessor extends AbstractProcessor {
                 .filter(element -> element.getKind().equals(ElementKind.METHOD))
                 .map(ExecutableElement.class::cast)
                 .forEach(possibleMethod -> {
+                    if (possibleMethod.getModifiers().contains(Modifier.DEFAULT)) {
+                        return;
+                    }
+
                     Name simpleName = possibleMethod.getSimpleName();
 
                     String returnType = possibleMethod.getReturnType().toString();

--- a/auto-parallelizable/src/test/resources/basic/input/Something.java
+++ b/auto-parallelizable/src/test/resources/basic/input/Something.java
@@ -19,6 +19,10 @@ public final class Something {
         RegularFileProperty getSomeFile();
 
         ConfigurableFileCollection getSomeFiles();
+
+        default String someStringsValue() {
+            return getSomeString().get();
+        }
     }
 
     static void action(Params params) {

--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`Params` default methods can be used without causing compile failures.'
+  links:
+  - https://github.com/palantir/auto-parallelizable/pull/5

--- a/integ-test/src/main/java/integtest/DoIt.java
+++ b/integ-test/src/main/java/integtest/DoIt.java
@@ -52,6 +52,10 @@ public final class DoIt {
 
         @InputFiles
         ConfigurableFileCollection getFilesValue();
+
+        default String stringsRealValue() {
+            return getStringValue().get();
+        }
     }
 
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")


### PR DESCRIPTION
## Before this PR
Currently, if you a default method in your params:

```java
interface Params {
    default int rollADie() {
        return 4;
    }
}
```

we try and generate code like:

```java
params.rollADie().set(rollADie());
```

which is obviously nonsense.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`Params` default methods can be used without causing compile failures.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

