### PR TITLE
Allow use of `@Nested` properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,32 @@ final class MyCustom {
     }
 }
 ```
+
+### Read-only managed nested properties 
+You can use [Read-only managed nested properties](https://docs.gradle.org/current/userguide/custom_gradle_types.html#read_only_managed_nested_properties) 
+in your `Params` interface. Properties will be recursively set.
+
+```java
+@AutoParallelizable
+final class MyCustom {
+    interface Nested {
+        @Input
+        Property<String> getString();
+    }
+    
+    interface Params {
+        @Nested
+        Nested getNested();
+
+        @OutputFile
+        RegularFileProperty getOutput();
+    }
+    
+    // action etc ...
+    
+    private MyCustom() {}
+}
+```
+
+_Note: If you are using a nested type you don't own, bear in mind that you will need to recompile against newer versions 
+to have any new properties copied over._  

--- a/README.md
+++ b/README.md
@@ -89,9 +89,23 @@ final class MyCustom {
         Property<String> getString();
     }
     
+    interface DoubleNested {
+        
+        Property<String> getDescription();
+        
+        @Nested
+        Nested getNested();
+    }
+    
     interface Params {
         @Nested
         Nested getNested();
+        
+        @Nested
+        DoubleNested getDoubleNested();
+        
+        @Nested
+        ListProperty<Nested> getNestedList();
 
         @OutputFile
         RegularFileProperty getOutput();

--- a/auto-parallelizable/src/main/java/com/palantir/gradle/autoparallelizable/AutoParallelizableProcessor.java
+++ b/auto-parallelizable/src/main/java/com/palantir/gradle/autoparallelizable/AutoParallelizableProcessor.java
@@ -20,6 +20,7 @@ import com.google.auto.common.MoreElements;
 import com.google.auto.common.MoreTypes;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -32,6 +33,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
@@ -44,10 +46,16 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic.Kind;
 
 @AutoService(Processor.class)
 public final class AutoParallelizableProcessor extends AbstractProcessor {
+
+    private static final Set<String> SETTABLE_PROPERTY_CLASSES = Set.of(
+            "org.gradle.api.provider.Property",
+            "org.gradle.api.provider.HasMultipleValues",
+            "org.gradle.api.provider.MapProperty");
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
@@ -195,7 +203,7 @@ public final class AutoParallelizableProcessor extends AbstractProcessor {
         return MoreElements.isAnnotationPresent(parameter, AutoParallelizable.Inject.class);
     }
 
-    private static boolean isNestedProperty(Element element) {
+    private static boolean isNested(Element element) {
         return MoreElements.isAnnotationPresent(element, "org.gradle.api.tasks.Nested");
     }
 
@@ -308,7 +316,7 @@ public final class AutoParallelizableProcessor extends AbstractProcessor {
                         return;
                     }
 
-                    if (isNestedProperty(possibleMethod)) {
+                    if (isNested(possibleMethod) && doesNotReturnASettableProperty(possibleMethod)) {
                         TypeElement nestedParamsLikeElement = MoreTypes.asTypeElement(possibleMethod.getReturnType());
                         String newContextSuffix = possibleMethod.getSimpleName().toString() + "()";
                         handleParamsLikeElement(
@@ -332,6 +340,23 @@ public final class AutoParallelizableProcessor extends AbstractProcessor {
                     builder.add(
                             "$L.$L().$L($L.$L());", writerContext, simpleName, setterMethod, readerContext, simpleName);
                 });
+    }
+
+    private boolean doesNotReturnASettableProperty(ExecutableElement method) {
+        Set<TypeElement> settablePropertyElements = SETTABLE_PROPERTY_CLASSES.stream()
+                .map(className -> processingEnv.getElementUtils().getTypeElement(className))
+                .collect(Collectors.toSet());
+        Set<TypeElement> returnTypeHierarchyElements = allSuperTypeElements(method.getReturnType());
+        return Sets.intersection(settablePropertyElements, returnTypeHierarchyElements)
+                .isEmpty();
+    }
+
+    private Set<TypeElement> allSuperTypeElements(TypeMirror type) {
+        return Stream.concat(
+                        Stream.of(MoreTypes.asTypeElement(type)),
+                        processingEnv.getTypeUtils().directSupertypes(type).stream()
+                                .flatMap(supertype -> allSuperTypeElements(supertype).stream()))
+                .collect(Collectors.toSet());
     }
 
     private static MethodSpec injectMethod(TypeName returns, String methodName) {

--- a/auto-parallelizable/src/test/resources/basic/output/SomethingTaskImpl.java
+++ b/auto-parallelizable/src/test/resources/basic/output/SomethingTaskImpl.java
@@ -14,9 +14,9 @@ abstract class SomethingTaskImpl extends DefaultTask implements Something.Params
     @TaskAction
     public final void execute() {
         getWorkerExecutor().noIsolation().submit(SomethingWorkAction.class, params -> {
-            params.getSomeString().set(getSomeString());
-            params.getSomeFile().set(getSomeFile());
-            params.getSomeFiles().from(getSomeFiles());
+            params.getSomeString().set(this.getSomeString());
+            params.getSomeFile().set(this.getSomeFile());
+            params.getSomeFiles().from(this.getSomeFiles());
         });
     }
 }

--- a/auto-parallelizable/src/test/resources/nested/input/Nested.java
+++ b/auto-parallelizable/src/test/resources/nested/input/Nested.java
@@ -17,7 +17,10 @@
 package app;
 
 import com.palantir.gradle.autoparallelizable.AutoParallelizable;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 
 @AutoParallelizable
 public final class Nested {
@@ -60,6 +63,18 @@ public final class Nested {
 
         @org.gradle.api.tasks.Nested
         TripleNested getTripleNestedInterface();
+
+        @org.gradle.api.tasks.Nested
+        SetProperty<NestedInterface> getSetPropertyNested();
+
+        @org.gradle.api.tasks.Nested
+        ListProperty<NestedInterface> getListPropertyNested();
+
+        @org.gradle.api.tasks.Nested
+        Property<NestedInterface> getPropertyNested();
+
+        @org.gradle.api.tasks.Nested
+        MapProperty<String, NestedInterface> getMapPropertyNested();
     }
 
     static void action(Params params) {

--- a/auto-parallelizable/src/test/resources/nested/input/Nested.java
+++ b/auto-parallelizable/src/test/resources/nested/input/Nested.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app;
+
+import com.palantir.gradle.autoparallelizable.AutoParallelizable;
+import org.gradle.api.provider.Property;
+
+@AutoParallelizable
+public final class Nested {
+    public abstract class NestedTask extends NestedTaskImpl {
+        public NestedTask() {
+            setDescription("lol");
+        }
+    }
+
+    interface NestedInterface {
+        public Property<String> getString();
+    }
+
+    interface DoublyNested {
+
+        Property<String> getDoubleString();
+
+        @org.gradle.api.tasks.Nested
+        NestedInterface getNestedInterface();
+    }
+
+    interface TripleNested {
+
+        Property<String> getTripleString();
+
+        Property<Integer> getTripleInteger();
+
+        @org.gradle.api.tasks.Nested
+        DoublyNested getDoublyNestedInterface();
+    }
+
+    interface Params {
+        Property<String> getSomeString();
+
+        @org.gradle.api.tasks.Nested
+        NestedInterface getNestedInterface();
+
+        @org.gradle.api.tasks.Nested
+        DoublyNested getDoublyNestedInterface();
+
+        @org.gradle.api.tasks.Nested
+        TripleNested getTripleNestedInterface();
+    }
+
+    static void action(Params params) {
+        System.out.println("Hello " + params.getSomeString().get());
+    }
+}

--- a/auto-parallelizable/src/test/resources/nested/output/NestedTaskImpl.java
+++ b/auto-parallelizable/src/test/resources/nested/output/NestedTaskImpl.java
@@ -1,0 +1,50 @@
+package app;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkerExecutor;
+
+@Generated("com.palantir.gradle.autoparallelizable.AutoParallelizableProcessor")
+abstract class NestedTaskImpl extends DefaultTask implements Nested.Params {
+    @Inject
+    protected abstract WorkerExecutor getWorkerExecutor();
+
+    @TaskAction
+    public final void execute() {
+        getWorkerExecutor().noIsolation().submit(NestedWorkAction.class, params -> {
+            params.getSomeString().set(this.getSomeString());
+            params.getNestedInterface()
+                    .getString()
+                    .set(this.getNestedInterface().getString());
+            params.getDoublyNestedInterface()
+                    .getDoubleString()
+                    .set(this.getDoublyNestedInterface().getDoubleString());
+            params.getDoublyNestedInterface()
+                    .getNestedInterface()
+                    .getString()
+                    .set(this.getDoublyNestedInterface().getNestedInterface().getString());
+            params.getTripleNestedInterface()
+                    .getTripleString()
+                    .set(this.getTripleNestedInterface().getTripleString());
+            params.getTripleNestedInterface()
+                    .getTripleInteger()
+                    .set(this.getTripleNestedInterface().getTripleInteger());
+            params.getTripleNestedInterface()
+                    .getDoublyNestedInterface()
+                    .getDoubleString()
+                    .set(this.getTripleNestedInterface()
+                            .getDoublyNestedInterface()
+                            .getDoubleString());
+            params.getTripleNestedInterface()
+                    .getDoublyNestedInterface()
+                    .getNestedInterface()
+                    .getString()
+                    .set(this.getTripleNestedInterface()
+                            .getDoublyNestedInterface()
+                            .getNestedInterface()
+                            .getString());
+        });
+    }
+}

--- a/auto-parallelizable/src/test/resources/nested/output/NestedTaskImpl.java
+++ b/auto-parallelizable/src/test/resources/nested/output/NestedTaskImpl.java
@@ -45,6 +45,10 @@ abstract class NestedTaskImpl extends DefaultTask implements Nested.Params {
                             .getDoublyNestedInterface()
                             .getNestedInterface()
                             .getString());
+            params.getSetPropertyNested().set(this.getSetPropertyNested());
+            params.getListPropertyNested().set(this.getListPropertyNested());
+            params.getPropertyNested().set(this.getPropertyNested());
+            params.getMapPropertyNested().set(this.getMapPropertyNested());
         });
     }
 }

--- a/auto-parallelizable/src/test/resources/nested/output/NestedWorkAction.java
+++ b/auto-parallelizable/src/test/resources/nested/output/NestedWorkAction.java
@@ -1,0 +1,15 @@
+package app;
+
+import javax.annotation.processing.Generated;
+import org.gradle.workers.WorkAction;
+
+@Generated("com.palantir.gradle.autoparallelizable.AutoParallelizableProcessor")
+abstract class NestedWorkAction implements WorkAction<NestedWorkParams> {
+    @SuppressWarnings("RedundantModifier")
+    public NestedWorkAction() {}
+
+    @Override
+    public final void execute() {
+        Nested.action(getParameters());
+    }
+}

--- a/auto-parallelizable/src/test/resources/nested/output/NestedWorkParams.java
+++ b/auto-parallelizable/src/test/resources/nested/output/NestedWorkParams.java
@@ -1,0 +1,7 @@
+package app;
+
+import javax.annotation.processing.Generated;
+import org.gradle.workers.WorkParameters;
+
+@Generated("com.palantir.gradle.autoparallelizable.AutoParallelizableProcessor")
+interface NestedWorkParams extends WorkParameters, Nested.Params {}

--- a/changelog/@unreleased/pr-26.v2.yml
+++ b/changelog/@unreleased/pr-26.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow use of `@Nested` properties inside `Params`.
+  links:
+  - https://github.com/palantir/auto-parallelizable/pull/26

--- a/integ-test/src/main/java/integtest/DoItNested.java
+++ b/integ-test/src/main/java/integtest/DoItNested.java
@@ -27,7 +27,6 @@ import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputFile;
 
 @AutoParallelizable

--- a/integ-test/src/main/java/integtest/DoItNested.java
+++ b/integ-test/src/main/java/integtest/DoItNested.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integtest;
+
+import com.palantir.gradle.autoparallelizable.AutoParallelizable;
+import java.io.File;
+import java.util.stream.Collectors;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+
+@AutoParallelizable
+public final class DoItNested {
+    public abstract static class DoItNestedTask extends DoItNestedTaskImpl {
+        public DoItNestedTask() {
+            setDescription("lol");
+        }
+    }
+
+    public abstract static class AbstractNested {
+        @OutputFile
+        abstract RegularFileProperty getFileValue();
+    }
+
+    interface Nested {
+        @Input
+        Property<String> getStringValue();
+
+        @InputFiles
+        ConfigurableFileCollection getFilesValue();
+    }
+
+    interface DoubleNested {
+
+        @Input
+        SetProperty<Integer> getIntsValue();
+
+        @org.gradle.api.tasks.Nested
+        Nested getNested();
+    }
+
+    interface Params {
+        @org.gradle.api.tasks.Nested
+        DoubleNested getDoubleNested();
+
+        @org.gradle.api.tasks.Nested
+        AbstractNested getAbstractNested();
+
+        @InputDirectory
+        DirectoryProperty getDirValue();
+    }
+
+    @SuppressWarnings("checkstyle:RegexpSinglelineJava")
+    static void action(Params params) {
+        System.out.println("string: "
+                + params.getDoubleNested().getNested().getStringValue().get());
+        System.out.println("file: "
+                + params.getAbstractNested().getFileValue().get().getAsFile().getName());
+        System.out.println("dir: " + params.getDirValue().get().getAsFile().getName());
+        System.out.println("ints: " + params.getDoubleNested().getIntsValue().get());
+        System.out.println("files: "
+                + params.getDoubleNested().getNested().getFilesValue().getFiles().stream()
+                        .map(File::getName)
+                        .collect(Collectors.joining(", ")));
+    }
+
+    private DoItNested() {}
+}

--- a/integ-test/src/main/java/integtest/DoItNested.java
+++ b/integ-test/src/main/java/integtest/DoItNested.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.Input;
@@ -42,7 +44,7 @@ public final class DoItNested {
         abstract RegularFileProperty getFileValue();
     }
 
-    interface Nested {
+    public interface Nested {
         @Input
         Property<String> getStringValue();
 
@@ -59,6 +61,20 @@ public final class DoItNested {
         Nested getNested();
     }
 
+    interface NestedProperties {
+        @org.gradle.api.tasks.Nested
+        ListProperty<Nested> getListProperty();
+
+        @org.gradle.api.tasks.Nested
+        SetProperty<Nested> getSetProperty();
+
+        @org.gradle.api.tasks.Nested
+        MapProperty<String, Nested> getMapProperty();
+
+        @org.gradle.api.tasks.Nested
+        Property<Nested> getProperty();
+    }
+
     interface Params {
         @org.gradle.api.tasks.Nested
         DoubleNested getDoubleNested();
@@ -68,6 +84,9 @@ public final class DoItNested {
 
         @InputDirectory
         DirectoryProperty getDirValue();
+
+        @org.gradle.api.tasks.Nested
+        NestedProperties getNestedProperties();
     }
 
     @SuppressWarnings("checkstyle:RegexpSinglelineJava")
@@ -82,6 +101,32 @@ public final class DoItNested {
                 + params.getDoubleNested().getNested().getFilesValue().getFiles().stream()
                         .map(File::getName)
                         .collect(Collectors.joining(", ")));
+        System.out.println("from property: "
+                + params.getNestedProperties()
+                        .getProperty()
+                        .get()
+                        .getStringValue()
+                        .get());
+        System.out.println("from list: "
+                + params.getNestedProperties()
+                        .getListProperty()
+                        .get()
+                        .get(0)
+                        .getStringValue()
+                        .get());
+        System.out.println("from set: "
+                + params.getNestedProperties().getSetProperty().get().stream()
+                        .findFirst()
+                        .get()
+                        .getStringValue()
+                        .get());
+        System.out.println("from map: "
+                + params.getNestedProperties()
+                        .getMapProperty()
+                        .get()
+                        .get("map")
+                        .getStringValue()
+                        .get());
     }
 
     private DoItNested() {}

--- a/integ-test/src/test/groovy/com/palantir/gradle/autoparallelizable/AutoParallelizableIntegSpec.groovy
+++ b/integ-test/src/test/groovy/com/palantir/gradle/autoparallelizable/AutoParallelizableIntegSpec.groovy
@@ -83,14 +83,25 @@ class AutoParallelizableIntegSpec extends IntegrationSpec {
 
         // language=gradle
         buildFile << '''
+            import integtest.DoItNested
             import integtest.DoItNested.DoItNestedTask
+            
+            DoItNested.Nested makeNested(value) {
+              def property = objects.newInstance(DoItNested.Nested)
+              property.stringValue = value
+              property
+            }
             
             task doIt(type: DoItNestedTask) {
                 doubleNested.nested.stringValue = 'heh'
                 abstractNested.fileValue = file('file')
                 dirValue = file('dir')
                 doubleNested.intsValue = [1, 2 ,3] 
-                doubleNested.nested.filesValue.from(file('lol1'), file('lol2'))
+                doubleNested.nested.filesValue.from(file('lol1'), file('lol2'))             
+                nestedProperties.setProperty.add(makeNested('set'))
+                nestedProperties.listProperty.add(makeNested('list'))
+                nestedProperties.mapProperty.put("map", makeNested('map'))
+                nestedProperties.property = makeNested('property')
             }
         '''.stripIndent(true)
 
@@ -103,6 +114,10 @@ class AutoParallelizableIntegSpec extends IntegrationSpec {
         stdout.contains 'dir: dir'
         stdout.contains 'ints: [1, 2, 3]'
         stdout.contains 'files: lol1, lol2'
+        stdout.contains 'from property: property'
+        stdout.contains 'from map: map'
+        stdout.contains 'from list: list'
+        stdout.contains 'from set: set'
     }
 
     def 'make sure it is incremental'() {

--- a/integ-test/src/test/groovy/com/palantir/gradle/autoparallelizable/AutoParallelizableIntegSpec.groovy
+++ b/integ-test/src/test/groovy/com/palantir/gradle/autoparallelizable/AutoParallelizableIntegSpec.groovy
@@ -77,6 +77,34 @@ class AutoParallelizableIntegSpec extends IntegrationSpec {
         stdout.contains 'files: lol1, lol2'
     }
 
+    def "@Nested read only managed properties are handled correctly"() {
+        file('file')
+        directory('dir')
+
+        // language=gradle
+        buildFile << '''
+            import integtest.DoItNested.DoItNestedTask
+            
+            task doIt(type: DoItNestedTask) {
+                doubleNested.nested.stringValue = 'heh'
+                abstractNested.fileValue = file('file')
+                dirValue = file('dir')
+                doubleNested.intsValue = [1, 2 ,3] 
+                doubleNested.nested.filesValue.from(file('lol1'), file('lol2'))
+            }
+        '''.stripIndent(true)
+
+        when:
+        def stdout = runTasksSuccessfully('doIt', '-Pautoparallelizable-inject-test=yes').standardOutput
+
+        then:
+        stdout.contains 'string: heh'
+        stdout.contains 'file: file'
+        stdout.contains 'dir: dir'
+        stdout.contains 'ints: [1, 2, 3]'
+        stdout.contains 'files: lol1, lol2'
+    }
+
     def 'make sure it is incremental'() {
         /* language=gradle */
         buildFile << '''


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`@Nested` ([read-only managed properties](https://docs.gradle.org/current/userguide/custom_gradle_types.html#read_only_managed_nested_properties)) is useful when trying to encapsulate some behaviour in Gradle. However, when you try to use it with `@AutoParallelizable` you will run into errors, as there's no nice copy constructor/method. Each `@Nested` property needs to be handled individually.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow use of `@Nested` properties inside `Params`.
==COMMIT_MSG==

For each `@Nested` property, we just rerun the setting code for each of the methods. This also works recursively, we just add a bit of context each time.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
As noted in the `README.md`, if you happen to use a type that you don't own/is not versioned with your plugin, you may run into subtle issues where properties are not copied correctly if a *newer* version of the extension with extra properties are used.

