### PR TITLE
ignore private methods and non-settable properties

### DIFF
--- a/auto-parallelizable/src/test/resources/abstract/input/Abstract.java
+++ b/auto-parallelizable/src/test/resources/abstract/input/Abstract.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app;
+
+import com.palantir.gradle.autoparallelizable.AutoParallelizable;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Nested;
+
+@AutoParallelizable
+public final class Abstract {
+    public abstract class AbstractTask extends AbstractTaskImpl {
+        public AbstractTask() {
+            setDescription("lol");
+        }
+    }
+
+    interface Nested {
+        public Property<String> getString();
+    }
+
+    abstract static class AbstractParams {
+        public abstract Property<String> getSettableNonNestedString();
+
+        public abstract Property<String> getStringWithParameters(String parameter);
+
+        private Property<String> getPrivateProperty() {
+            return null;
+        }
+
+        public abstract Nested getNonNestedNonSettableProperty();
+    }
+
+    interface Params {
+        @org.gradle.api.tasks.Nested
+        AbstractParams getAbstractParams();
+    }
+
+    static void action(Params params) {
+        System.out.println("Hello "
+                + params.getAbstractParams().getSettableNonNestedString().get());
+    }
+}

--- a/auto-parallelizable/src/test/resources/abstract/output/AbstractTaskImpl.java
+++ b/auto-parallelizable/src/test/resources/abstract/output/AbstractTaskImpl.java
@@ -1,0 +1,22 @@
+package app;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkerExecutor;
+
+@Generated("com.palantir.gradle.autoparallelizable.AutoParallelizableProcessor")
+abstract class AbstractTaskImpl extends DefaultTask implements Abstract.Params {
+    @Inject
+    protected abstract WorkerExecutor getWorkerExecutor();
+
+    @TaskAction
+    public final void execute() {
+        getWorkerExecutor().noIsolation().submit(AbstractWorkAction.class, params -> {
+            params.getAbstractParams()
+                    .getSettableNonNestedString()
+                    .set(this.getAbstractParams().getSettableNonNestedString());
+        });
+    }
+}

--- a/auto-parallelizable/src/test/resources/abstract/output/AbstractWorkAction.java
+++ b/auto-parallelizable/src/test/resources/abstract/output/AbstractWorkAction.java
@@ -1,0 +1,15 @@
+package app;
+
+import javax.annotation.processing.Generated;
+import org.gradle.workers.WorkAction;
+
+@Generated("com.palantir.gradle.autoparallelizable.AutoParallelizableProcessor")
+abstract class AbstractWorkAction implements WorkAction<AbstractWorkParams> {
+    @SuppressWarnings("RedundantModifier")
+    public AbstractWorkAction() {}
+
+    @Override
+    public final void execute() {
+        Abstract.action(getParameters());
+    }
+}

--- a/auto-parallelizable/src/test/resources/abstract/output/AbstractWorkParams.java
+++ b/auto-parallelizable/src/test/resources/abstract/output/AbstractWorkParams.java
@@ -1,0 +1,7 @@
+package app;
+
+import javax.annotation.processing.Generated;
+import org.gradle.workers.WorkParameters;
+
+@Generated("com.palantir.gradle.autoparallelizable.AutoParallelizableProcessor")
+interface AbstractWorkParams extends WorkParameters, Abstract.Params {}

--- a/changelog/@unreleased/pr-27.v2.yml
+++ b/changelog/@unreleased/pr-27.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Stricter filtering on what is and isn't settable.
+  links:
+  - https://github.com/palantir/auto-parallelizable/pull/27


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If you had an abstract class with private methods or public methods with parameters, it would try to start assigning those fields even though it doesn't make any sense.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Stricter filtering on what is and isn't settable.
==COMMIT_MSG==

Now we ensure that for a method to be assigned it:
* is not private
* is a zero arg method
* it's either nested
* or it is settable i.e. derives from some sort of `Property`, had to include `ConfigurableFilesCollection` as I had missed that last time round.

## Possible downsides?
It feels very whack-a-mole. It gets us to our goal of more parallelisable things, but I wonder whether we can do a two-pronged approach with trying to attack the configuration cache (which supposedly gets you parallel runs for free as well).

